### PR TITLE
(WIP) Pattern Editor Submenu Revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 prune-tags.sh
 paketti.sublime-project
 paketti.sublime-workspace
-xrnx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 prune-tags.sh
 paketti.sublime-project
 paketti.sublime-workspace
+xrnx

--- a/PakettiActionSelector.lua
+++ b/PakettiActionSelector.lua
@@ -380,5 +380,5 @@ end
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Mixer:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}

--- a/PakettiActionSelector.lua
+++ b/PakettiActionSelector.lua
@@ -380,5 +380,5 @@ end
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Mixer:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}

--- a/PakettiActionSelector.lua
+++ b/PakettiActionSelector.lua
@@ -378,7 +378,7 @@ end
 -- song.instruments[i].name = ensure_sequential_channel_prefix(song.instruments[i].name, i)
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="Mixer:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}

--- a/PakettiActionSelector.lua
+++ b/PakettiActionSelector.lua
@@ -380,5 +380,5 @@ end
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Mixer:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}

--- a/PakettiActionSelector.lua
+++ b/PakettiActionSelector.lua
@@ -380,5 +380,5 @@ end
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Mixer:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Action Selector Dialog...",invoke = pakettiActionSelectorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Action Selector Dialog...",invoke = pakettiActionSelectorDialog}

--- a/PakettiAutomation.lua
+++ b/PakettiAutomation.lua
@@ -1345,7 +1345,7 @@ then w.active_lower_frame = raw.LOWER_FRAME_TRACK_DSPS return end
     w.lock_keyboard_focus=true
     renoise.song().transport.follow_player=false end
 
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Switch to Automation",invoke=function() showAutomation() end}
+
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Switch to Automation",invoke=function() showAutomation() end}
 renoise.tool():add_keybinding{name="Pattern Matrix:Paketti:Switch to Automation",invoke=function() showAutomation() end}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Switch to Automation",invoke=function() showAutomation() end}

--- a/PakettiBPMToMS.lua
+++ b/PakettiBPMToMS.lua
@@ -116,7 +116,7 @@ function pakettiBPMMSCalculator()
 end
 
 renoise.tool():add_menu_entry {name = "Main Menu:Tools:Paketti..:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}
-renoise.tool():add_menu_entry {name = "Pattern Editor:Paketti..:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}
+renoise.tool():add_menu_entry {name = "--Pattern Editor:Paketti..:BPM&LPB..:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}
 renoise.tool():add_menu_entry {name = "Pattern Matrix:Paketti..:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}
 renoise.tool():add_menu_entry {name = "Mixer:Paketti..:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}
 renoise.tool():add_keybinding {name = "Global:Paketti:Paketti BPM to MS Delay Calculator Dialog...", invoke = pakettiBPMMSCalculator}

--- a/PakettiChordsPlus.lua
+++ b/PakettiChordsPlus.lua
@@ -461,9 +461,9 @@ function NoteSorterDescending()
 end
 
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Note Sorter (Ascending)",invoke=NoteSorterAscending}
-  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Sorter (Ascending)",invoke=NoteSorterAscending}
+  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Note Sorter (Ascending)",invoke=NoteSorterAscending}
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Note Sorter (Descending)",invoke=NoteSorterDescending}
-  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Sorter (Descending)",invoke=NoteSorterDescending}
+  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Note Sorter (Descending)",invoke=NoteSorterDescending}
 ---  
   function RandomizeVoicing()
     local song=renoise.song()
@@ -668,8 +668,8 @@ renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti ChordsPlus..:Random
   
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Shift Notes Right",invoke=function() ShiftNotes(1) end}
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
-  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Shift Notes Right",invoke=function() ShiftNotes(1) end}
-  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
+  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Shift Notes Right",invoke=function() ShiftNotes(1) end}
+  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
   
   
 

--- a/PakettiChordsPlus.lua
+++ b/PakettiChordsPlus.lua
@@ -463,7 +463,7 @@ end
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Note Sorter (Ascending)",invoke=NoteSorterAscending}
   renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Note Sorter (Ascending)",invoke=NoteSorterAscending}
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Note Sorter (Descending)",invoke=NoteSorterDescending}
-  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Note Sorter (Descending)",invoke=NoteSorterDescending}
+  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Note Sorter (Descending)",invoke=NoteSorterDescending}
 ---  
   function RandomizeVoicing()
     local song=renoise.song()
@@ -669,7 +669,7 @@ renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti ChordsPlus..:Random
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Shift Notes Right",invoke=function() ShiftNotes(1) end}
   renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
   renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Shift Notes Right",invoke=function() ShiftNotes(1) end}
-  renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
+  renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Shift Notes Left",invoke=function() ShiftNotes(-1) end}
   
   
 

--- a/PakettiControls.lua
+++ b/PakettiControls.lua
@@ -1503,59 +1503,24 @@ renoise.tool():add_keybinding{name="Global:Paketti:Nudge Delay Output Delay -05m
 renoise.tool():add_keybinding{name="Global:Paketti:Reset Nudge Delay Output Delay to 0ms (Rename)",invoke=function() reset_output_delay(true) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Reset Nudge Delay Output Delay to 0ms (ALL) (Rename)",invoke=function() reset_output_delayALL(true) end}
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +01ms",invoke=function() nudge_output_delay(1, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -01ms",invoke=function() nudge_output_delay(-1, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +05ms",invoke=function() nudge_output_delay(5, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -05ms",invoke=function() nudge_output_delay(-5, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +10ms",invoke=function() nudge_output_delay(10, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -10ms",invoke=function() nudge_output_delay(-10, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms",invoke=function() reset_output_delay(false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL)",invoke=function() reset_output_delayALL(false) end}
-
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +01ms (Rename)",invoke=function() nudge_output_delay(1, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -01ms (Rename)",invoke=function() nudge_output_delay(-1, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +05ms (Rename)",invoke=function() nudge_output_delay(5, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -05ms (Rename)",invoke=function() nudge_output_delay(-5, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output +10ms (Rename)",invoke=function() nudge_output_delay(10, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Nudge Delay Output -10ms (Rename)",invoke=function() nudge_output_delay(-10, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (Rename)",invoke=function() reset_output_delay(true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL) (Rename)",invoke=function() reset_output_delayALL(true) end}
-
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +01ms",invoke=function() nudge_output_delay(1, false) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -01ms",invoke=function() nudge_output_delay(-1, false) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +05ms",invoke=function() nudge_output_delay(5, false) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -05ms",invoke=function() nudge_output_delay(-5, false) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +10ms",invoke=function() nudge_output_delay(10, false) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -10ms",invoke=function() nudge_output_delay(-10, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output +01ms",invoke=function() nudge_output_delay(1, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -01ms",invoke=function() nudge_output_delay(-1, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output +05ms",invoke=function() nudge_output_delay(5, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -05ms",invoke=function() nudge_output_delay(-5, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output +10ms",invoke=function() nudge_output_delay(10, false) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -10ms",invoke=function() nudge_output_delay(-10, false) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms",invoke=function() reset_output_delay(false) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL)",invoke=function() reset_output_delayALL(false) end}
 
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +01ms (Rename)",invoke=function() nudge_output_delay(1, true) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -01ms (Rename)",invoke=function() nudge_output_delay(-1, true) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +05ms (Rename)",invoke=function() nudge_output_delay(5, true) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -05ms (Rename)",invoke=function() nudge_output_delay(-5, true) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay +10ms (Rename)",invoke=function() nudge_output_delay(10, true) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output Delay -10ms (Rename)",invoke=function() nudge_output_delay(-10, true) end}
+renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Delay Output..:Nudge Delay Output +01ms (Rename)",invoke=function() nudge_output_delay(1, true) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -01ms (Rename)",invoke=function() nudge_output_delay(-1, true) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output +05ms (Rename)",invoke=function() nudge_output_delay(5, true) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -05ms (Rename)",invoke=function() nudge_output_delay(-5, true) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output +10ms (Rename)",invoke=function() nudge_output_delay(10, true) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Nudge Delay Output -10ms (Rename)",invoke=function() nudge_output_delay(-10, true) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (Rename)",invoke=function() reset_output_delay(true) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL) (Rename)",invoke=function() reset_output_delayALL(true) end}
 
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +01ms",invoke=function() nudge_output_delay(1, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -01ms",invoke=function() nudge_output_delay(-1, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +05ms",invoke=function() nudge_output_delay(5, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -05ms",invoke=function() nudge_output_delay(-5, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +10ms",invoke=function() nudge_output_delay(10, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -10ms",invoke=function() nudge_output_delay(-10, false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms",invoke=function() reset_output_delay(false) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL)",invoke=function() reset_output_delayALL(false) end}
-
-renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +01ms (Rename)",invoke=function() nudge_output_delay(1, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -01ms (Rename)",invoke=function() nudge_output_delay(-1, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +05ms (Rename)",invoke=function() nudge_output_delay(5, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -05ms (Rename)",invoke=function() nudge_output_delay(-5, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay +10ms (Rename)",invoke=function() nudge_output_delay(10, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Nudge Delay Output Delay -10ms (Rename)",invoke=function() nudge_output_delay(-10, true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (Rename)",invoke=function() reset_output_delay(true) end}
-renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Delay Output..:Reset Delay Output Delay to 0ms (ALL) (Rename)",invoke=function() reset_output_delayALL(true) end}
 
 -----
 

--- a/PakettiEightOneTwenty.lua
+++ b/PakettiEightOneTwenty.lua
@@ -1933,7 +1933,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Groovebox 8120",invoke=function() GrooveboxShowClose() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
 
 renoise.tool():add_midi_mapping{name="Paketti:Paketti Groovebox 8120",invoke=function(message)
   if message:is_trigger() then

--- a/PakettiEightOneTwenty.lua
+++ b/PakettiEightOneTwenty.lua
@@ -1933,6 +1933,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Groovebox 8120",invoke=function() GrooveboxShowClose() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
 
 renoise.tool():add_midi_mapping{name="Paketti:Paketti Groovebox 8120",invoke=function(message)
   if message:is_trigger() then

--- a/PakettiEightOneTwenty.lua
+++ b/PakettiEightOneTwenty.lua
@@ -1933,7 +1933,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Groovebox 8120",invoke=function() GrooveboxShowClose() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Groovebox 8120...",invoke=function() GrooveboxShowClose() end}
 
 renoise.tool():add_midi_mapping{name="Paketti:Paketti Groovebox 8120",invoke=function(message)
   if message:is_trigger() then

--- a/PakettiExperimental_Verify.lua
+++ b/PakettiExperimental_Verify.lua
@@ -1021,7 +1021,7 @@ function AutoAssignOutputs()
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Auto Assign Outputs",invoke=AutoAssignOutputs}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Auto Assign Outputs",invoke=AutoAssignOutputs}
+renoise.tool():add_menu_entry{name="---Pattern Editor:Paketti..:Tracks..:Auto Assign Outputs",invoke=AutoAssignOutputs}
 renoise.tool():add_menu_entry{name="Mixing:Paketti..:Auto Assign Outputs",invoke=AutoAssignOutputs}
 
 ---
@@ -3015,7 +3015,7 @@ function PakettiToggleSoloTracks()
 end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Pattern Editor..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Mixer..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 renoise.tool():add_midi_mapping{name="Paketti:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 
@@ -3095,7 +3095,7 @@ function set_group_mute_state(group, mute_state)
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 renoise.tool():add_midi_mapping{name="Paketti:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 

--- a/PakettiExperimental_Verify.lua
+++ b/PakettiExperimental_Verify.lua
@@ -153,12 +153,12 @@ function createPatternSequencerPatternsBasedOnSliceCount()
 end
 
 -- Menu entry and keybinding for the new function
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
-renoise.tool():add_menu_entry{name="Pattern Sequencer:Paketti..:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
-renoise.tool():add_keybinding{name="Global:Paketti:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
+renoise.tool():add_menu_entry{name="--Pattern Sequencer:Paketti..:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
+renoise.tool():add_keybinding{name="--Global:Paketti:Create Pattern Sequencer Patterns based on Slice Count with Automatic Slice Printing",invoke = createPatternSequencerPatternsBasedOnSliceCount}
 
 ----
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Wipe&Slice&Write to Pattern",invoke = function() WipeSliceAndWrite() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Wipe&Slice&Write to Pattern",invoke = function() WipeSliceAndWrite() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Wipe&Slice&Write to Pattern",invoke = function() WipeSliceAndWrite() end}
 
 function WipeSliceAndWrite()
@@ -825,12 +825,12 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Write Notes Random",i
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Write Notes EditStep Ascending",invoke=function() writeNotesMethodEditStep("ascending") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Write Notes EditStep Descending",invoke=function() writeNotesMethodEditStep("descending") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Write Notes EditStep Random",invoke=function() writeNotesMethodEditStep("random") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes Ascending",invoke=function() writeNotesMethod("ascending") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes Descending",invoke=function() writeNotesMethod("descending") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes Random",invoke=function() writeNotesMethod("random") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes EditStep Ascending",invoke=function() writeNotesMethodEditStep("ascending") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes EditStep Descending",invoke=function() writeNotesMethodEditStep("descending") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write Notes..:Write Notes EditStep Random",invoke=function() writeNotesMethodEditStep("random") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes Ascending",invoke=function() writeNotesMethod("ascending") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes Descending",invoke=function() writeNotesMethod("descending") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes Random",invoke=function() writeNotesMethod("random") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes EditStep Ascending",invoke=function() writeNotesMethodEditStep("ascending") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes EditStep Descending",invoke=function() writeNotesMethodEditStep("descending") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write Notes..:Write Notes EditStep Random",invoke=function() writeNotesMethodEditStep("random") end}
 
 
 
@@ -1021,7 +1021,7 @@ function AutoAssignOutputs()
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Auto Assign Outputs",invoke=AutoAssignOutputs}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Auto Assign Outputs",invoke=AutoAssignOutputs}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Auto Assign Outputs",invoke=AutoAssignOutputs}
 renoise.tool():add_menu_entry{name="Mixing:Paketti..:Auto Assign Outputs",invoke=AutoAssignOutputs}
 
 ---
@@ -3015,7 +3015,7 @@ function PakettiToggleSoloTracks()
 end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Pattern Editor..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Mixer..:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 renoise.tool():add_midi_mapping{name="Paketti:Toggle Solo Tracks",invoke=PakettiToggleSoloTracks}
 
@@ -3095,7 +3095,7 @@ function set_group_mute_state(group, mute_state)
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 renoise.tool():add_midi_mapping{name="Paketti:Toggle Mute Tracks",invoke=toggle_mute_tracks}
 
@@ -4582,11 +4582,11 @@ function GenerateDelayValue(scope)
 end
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value on Note Columns",invoke=function() GenerateDelayValue("row") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value on Note Columns",invoke=function() GenerateDelayValue("row") end}
+renoise.tool():add_menu_entry{name="---Pattern Editor:Paketti..:Note Columns..:Generate Delay Value on Note Columns",invoke=function() GenerateDelayValue("row") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value on Entire Pattern",invoke=function() GenerateDelayValue("pattern") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value on Entire Pattern",invoke=function() GenerateDelayValue("pattern") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Generate Delay Value on Entire Pattern",invoke=function() GenerateDelayValue("pattern") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value on Selection",invoke=function() GenerateDelayValue("selection") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value on Selection",invoke=function() GenerateDelayValue("selection") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Generate Delay Value on Selection",invoke=function() GenerateDelayValue("selection") end}
 -------
 
 -- Function to get selected columns in the current selection

--- a/PakettiExperimental_Verify.lua
+++ b/PakettiExperimental_Verify.lua
@@ -4659,11 +4659,11 @@ end
 
 -- Add new keybindings for note-specific version
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value (Notes Only, Row)",invoke=function() GenerateDelayValueNotes("row") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value (Notes Only, Row)",invoke=function() GenerateDelayValueNotes("row") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Generate Delay Value (Notes Only, Row)",invoke=function() GenerateDelayValueNotes("row") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value (Notes Only, Pattern)",invoke=function() GenerateDelayValueNotes("pattern") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value (Notes Only, Pattern)",invoke=function() GenerateDelayValueNotes("pattern") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Generate Delay Value (Notes Only, Pattern)",invoke=function() GenerateDelayValueNotes("pattern") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Generate Delay Value (Notes Only, Selection)",invoke=function() GenerateDelayValueNotes("selection") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate Delay Value (Notes Only, Selection)",invoke=function() GenerateDelayValueNotes("selection") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Generate Delay Value (Notes Only, Selection)",invoke=function() GenerateDelayValueNotes("selection") end}
 
 -------
 -- Global variable to track which column cycling is active for

--- a/PakettiGlobalGrooveToDelayValues.lua
+++ b/PakettiGlobalGrooveToDelayValues.lua
@@ -319,6 +319,6 @@ function pakettiGrooveToDelay()
   end
 end
 
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Convert Global Groove to Delay on Selected Track/Group",invoke=pakettiGrooveToDelay}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Convert Global Groove to Delay on Selected Track/Group",invoke=pakettiGrooveToDelay}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Convert Global Groove to Delay on Selected Track/Group",invoke=pakettiGrooveToDelay}
 renoise.tool():add_midi_mapping{name="Pattern Editor:Paketti:Convert Global Groove to Delay on Selected Track/Group",invoke=function(message) if message:is_trigger() then pakettiGrooveToDelay() end end}

--- a/PakettiKeyBindings.lua
+++ b/PakettiKeyBindings.lua
@@ -1072,8 +1072,8 @@ for _, menu_name in ipairs(menu_entries) do
   -- Get the correct identifier (handle special cases)
   local identifier = menu_to_identifier[menu_name] or menu_name
   
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti Gadgets..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti Gadgets..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:!Preferences..:Renoise KeyBindings...",

--- a/PakettiKeyBindings.lua
+++ b/PakettiKeyBindings.lua
@@ -1072,8 +1072,8 @@ for _, menu_name in ipairs(menu_entries) do
   -- Get the correct identifier (handle special cases)
   local identifier = menu_to_identifier[menu_name] or menu_name
   
-  renoise.tool():add_menu_entry{name=menu_name .. ":--Paketti..:Paketti Tools..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Tools..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":--Paketti..:Paketti Gadgets..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Gadgets..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:!Preferences..:Renoise KeyBindings...",

--- a/PakettiKeyBindings.lua
+++ b/PakettiKeyBindings.lua
@@ -1072,8 +1072,8 @@ for _, menu_name in ipairs(menu_entries) do
   -- Get the correct identifier (handle special cases)
   local identifier = menu_to_identifier[menu_name] or menu_name
   
-  renoise.tool():add_menu_entry{name=menu_name .. ":--Paketti..:Paketti Gadgets..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Gadgets..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti Gadgets..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti Gadgets..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:!Preferences..:Renoise KeyBindings...",

--- a/PakettiKeyBindings.lua
+++ b/PakettiKeyBindings.lua
@@ -1072,7 +1072,7 @@ for _, menu_name in ipairs(menu_entries) do
   -- Get the correct identifier (handle special cases)
   local identifier = menu_to_identifier[menu_name] or menu_name
   
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Tools..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":--Paketti..:Paketti Tools..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
   renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Tools..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
 end
 

--- a/PakettiKeyBindings.lua
+++ b/PakettiKeyBindings.lua
@@ -1072,8 +1072,8 @@ for _, menu_name in ipairs(menu_entries) do
   -- Get the correct identifier (handle special cases)
   local identifier = menu_to_identifier[menu_name] or menu_name
   
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
-  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Tools..:Show Paketti KeyBindings...",invoke=function() pakettiKeyBindingsDialog(identifier) end}
+  renoise.tool():add_menu_entry{name=menu_name .. ":Paketti..:Paketti Tools..:Show Renoise KeyBindings...",invoke=function() pakettiRenoiseKeyBindingsDialog(identifier) end}
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:!Preferences..:Renoise KeyBindings...",

--- a/PakettiLoaders.lua
+++ b/PakettiLoaders.lua
@@ -3091,8 +3091,8 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
-renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Devices..:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
+renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Devices..:Insert Stereo -> Mono device to End of ALL DSP Chains",invoke=function() insertMonoToAllTracksEnd() end}
 -----
 -- LFO Shape control functions
 local function get_lfo_device()

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -410,7 +410,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti New Song Dialog...",invoke=function() pakettiImpulseTrackerNewSongDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Track Dater & Titler...",invoke=function() pakettiTitlerDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Theme Selector...",invoke=pakettiThemeSelectorDialogShow }

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -410,7 +410,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti New Song Dialog...",invoke=function() pakettiImpulseTrackerNewSongDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Track Dater & Titler...",invoke=function() pakettiTitlerDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Theme Selector...",invoke=pakettiThemeSelectorDialogShow }

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -236,6 +236,7 @@ end
 
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Effect Column CheatSheet...",invoke=function() pakettiPatternEditorCheatsheetDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Effect Column CheatSheet...",invoke=function() pakettiPatternEditorCheatsheetDialog() end}
 
 -------- Plugins/Devices
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Plugins/Devices..:Load Devices...",invoke=function()

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -236,7 +236,7 @@ end
 
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Effect Column CheatSheet...",invoke=function() pakettiPatternEditorCheatsheetDialog() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Effect Column CheatSheet...",invoke=function() pakettiPatternEditorCheatsheetDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Effect Column CheatSheet...",invoke=function() pakettiPatternEditorCheatsheetDialog() end}
 
 -------- Plugins/Devices
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Plugins/Devices..:Load Devices...",invoke=function()
@@ -421,7 +421,7 @@ renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Gater...",
             renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
           end
         end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Gater...",invoke=function()
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Gater...",invoke=function()
           local max_rows = renoise.song().selected_pattern.number_of_lines
           if renoise.song() then
             pakettiGaterDialog()

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -421,7 +421,7 @@ renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Gater...",
             renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
           end
         end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Paketti Gater...",invoke=function()
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Gater...",invoke=function()
           local max_rows = renoise.song().selected_pattern.number_of_lines
           if renoise.song() then
             pakettiGaterDialog()

--- a/PakettiMainMenuEntries.lua
+++ b/PakettiMainMenuEntries.lua
@@ -409,6 +409,7 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Toggle Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Dialog of Dialogs...",invoke=function() pakettiDialogOfDialogsToggle() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti New Song Dialog...",invoke=function() pakettiImpulseTrackerNewSongDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Track Dater & Titler...",invoke=function() pakettiTitlerDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Theme Selector...",invoke=pakettiThemeSelectorDialogShow }
@@ -419,6 +420,13 @@ renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Gater...",
             renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
           end
         end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:Paketti Gater...",invoke=function()
+          local max_rows = renoise.song().selected_pattern.number_of_lines
+          if renoise.song() then
+            pakettiGaterDialog()
+            renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
+          end
+        end}        
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti MIDI Populator...",invoke=function() pakettiMIDIPopulator() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Track Routings...",invoke=function() pakettiTrackOutputRoutingsDialog() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Oblique Strategies...",invoke=function() create_oblique_strategies_dialog() end}

--- a/PakettiMidi.lua
+++ b/PakettiMidi.lua
@@ -2072,7 +2072,7 @@ end
 
 renoise.tool():add_midi_mapping{name="Paketti:Write 0Sxx Command Random Slice/Offset x[Toggle]",invoke=function(message) if message:is_trigger() then write_random_slice_command() end end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Write 0Sxx Command Random Slice/Offset",invoke=function() write_random_slice_command() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Write 0Sxx Command Random Slice/Offset",invoke=function() write_random_slice_command() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Write 0Sxx Command Random Slice/Offset",invoke=function() write_random_slice_command() end}
 
 -- Function to rename tracks based on actual samples being played
 function rename_tracks_by_played_samples()
@@ -2172,7 +2172,7 @@ function rename_tracks_by_played_samples()
 end
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Rename Tracks By Played Samples",invoke=function() rename_tracks_by_played_samples() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Rename Tracks By Played Samples",invoke=function() rename_tracks_by_played_samples() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Rename Tracks By Played Samples",invoke=function() rename_tracks_by_played_samples() end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Rename Tracks By Played Samples",invoke=function() rename_tracks_by_played_samples() end}
 -----
 -- Function to modify selected XY Pad parameter

--- a/PakettiPatternEditor.lua
+++ b/PakettiPatternEditor.lua
@@ -2334,7 +2334,7 @@ end
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 renoise.tool():add_midi_mapping{name="Paketti:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..Flood Fill Note and Instrument",invoke=pakettiFloodFill}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 -----------
 -- Function to Flood Fill the track with the current note and instrument with an edit step
 function pakettiFloodFillWithEditStep()

--- a/PakettiPatternEditor.lua
+++ b/PakettiPatternEditor.lua
@@ -4748,15 +4748,15 @@ end
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Hard Left",invoke=function() globalLeft() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Hard Right",invoke=function() globalRight() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Tracks..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
-renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
-renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
+renoise.tool():add_menu_entry{name="--DSP Device:Paketti..:Tracks..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Tracks..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
+renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Tracks..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
 
 
 

--- a/PakettiPatternEditor.lua
+++ b/PakettiPatternEditor.lua
@@ -206,8 +206,8 @@ renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:U
 
 renoise.tool():add_keybinding{name="Global:Paketti:Uncollapse All Tracks",invoke=function() Uncollapser() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Collapse All Tracks",invoke=function() Collapser() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Uncollapse All Tracks",invoke=function() Uncollapser() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Collapse All Tracks",invoke=function() Collapser() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Uncollapse All Tracks",invoke=function() Uncollapser() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Collapse All Tracks",invoke=function() Collapser() end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Uncollapse All Tracks",invoke=function() Uncollapser() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Collapse All Tracks",invoke=function() Collapser() end}
 renoise.tool():add_menu_entry{name="--Main Menu:View:Paketti..:Visible Columns..:Uncollapse All Tracks",invoke=function() Uncollapser() end}
@@ -770,8 +770,8 @@ renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Pattern Editor..
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Paketti Pattern Halver",invoke=pakettiPatternHalver}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Paketti Pattern Doubler",invoke=pakettiPatternDoubler}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Paketti Pattern Halver",invoke=pakettiPatternHalver}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Paketti Pattern Doubler",invoke=pakettiPatternDoubler}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Paketti Pattern Halver",invoke=pakettiPatternHalver}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Paketti Pattern Doubler",invoke=pakettiPatternDoubler}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Paketti Pattern Halver",invoke=pakettiPatternHalver}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Paketti Pattern Doubler",invoke=pakettiPatternDoubler}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Paketti Pattern Halver",invoke=pakettiPatternHalver}
 
@@ -2334,7 +2334,7 @@ end
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 renoise.tool():add_midi_mapping{name="Paketti:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Flood Fill Note and Instrument",invoke=pakettiFloodFill}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..Flood Fill Note and Instrument",invoke=pakettiFloodFill}
 -----------
 -- Function to Flood Fill the track with the current note and instrument with an edit step
 function pakettiFloodFillWithEditStep()
@@ -2480,7 +2480,7 @@ end
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Flood Fill Note and Instrument with EditStep",invoke=pakettiFloodFillWithEditStep}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Flood Fill Note and Instrument with EditStep",invoke=pakettiFloodFillWithEditStep}
 renoise.tool():add_midi_mapping{name="Paketti:Flood Fill Note and Instrument with EditStep",invoke=pakettiFloodFillWithEditStep}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Flood Fill Note and Instrument with EditStep",invoke=pakettiFloodFillWithEditStep}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Flood Fill Note and Instrument with EditStep",invoke=pakettiFloodFillWithEditStep}
 
 
 --------------------
@@ -4105,8 +4105,8 @@ end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Xperimental/Work in Progress..:Match Effect Column EditStep with Note Placement",invoke=function() toggle_match_editstep_effect() end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Xperimental/Work in Progress..:Match Note Column EditStep with Note Placement",invoke=function() toggle_match_editstep_note() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Match Effect Column EditStep with Note Placement",invoke=function() toggle_match_editstep_effect() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Match Note Column EditStep with Note Placement",invoke=function() toggle_match_editstep_note() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Xperimental/Work in Progress..:Match Effect Column EditStep with Note Placement",invoke=function() toggle_match_editstep_effect() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Xperimental/Work in Progress..:Match Note Column EditStep with Note Placement",invoke=function() toggle_match_editstep_note() end}
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Match EditStep with Note Placement (Effect Column)",invoke=function() toggle_match_editstep_effect() end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Match EditStep with Note Placement (Note Column)",invoke=function() toggle_match_editstep_note() end}
@@ -4182,10 +4182,10 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Clear Selected Track 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Clear Selected Track Below Current Row",invoke=function() clear_track_direction("below",false) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Clear All Tracks Above Current Row",invoke=function() clear_track_direction("above",true) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Clear All Tracks Below Current Row",invoke=function() clear_track_direction("below",true) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Clear Selected Track Above Current Row",invoke=function() clear_track_direction("above",false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Clear Selected Track Below Current Row",invoke=function() clear_track_direction("below",false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Clear All Tracks Above Current Row",invoke=function() clear_track_direction("above",true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Clear All Tracks Below Current Row",invoke=function() clear_track_direction("below",true) end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Clear Selected Track Above Current Row",invoke=function() clear_track_direction("above",false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Clear Selected Track Below Current Row",invoke=function() clear_track_direction("below",false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Clear All Tracks Above Current Row",invoke=function() clear_track_direction("above",true) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Clear All Tracks Below Current Row",invoke=function() clear_track_direction("below",true) end}
 renoise.tool():add_midi_mapping{name="Paketti:Clear Selected Track Above Current Row",invoke=function(message) if message:is_trigger() then clear_track_direction("above", false) end end}
 renoise.tool():add_midi_mapping{name="Paketti:Clear Selected Track Below Current Row",invoke=function(message) if message:is_trigger() then clear_track_direction("below", false) end end}
 renoise.tool():add_midi_mapping{name="Paketti:Clear All Tracks Above Current Row",invoke=function(message) if message:is_trigger() then clear_track_direction("above", true) end end}
@@ -4748,15 +4748,15 @@ end
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Hard Left",invoke=function() globalLeft() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Hard Right",invoke=function() globalRight() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
-renoise.tool():add_menu_entry{name="--DSP Device:Paketti..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
-renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
-renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Mixer..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
+renoise.tool():add_menu_entry{name="--DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Hard Left",invoke=function() globalLeft() end}
+renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Hard Right",invoke=function() globalRight() end}
+renoise.tool():add_menu_entry{name="DSP Device:Paketti..:Mixer..:Panning - Set All Tracks to Center",invoke=function() globalCenter() end}
 
 
 
@@ -5145,8 +5145,8 @@ function SelectionToNewPattern()
 Deselect_All()
 end
 
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Create New Pattern with Selection",invoke=function() SelectionToNewPattern() end}
-renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Create New Pattern with Selection",invoke=function() SelectionToNewPattern() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Create New Pattern from Selection",invoke=function() SelectionToNewPattern() end}
+renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Create New Pattern from Selection",invoke=function() SelectionToNewPattern() end}
 ---
 function HideAllEffectColumns()
   local song=renoise.song()
@@ -5206,8 +5206,8 @@ end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Move Track Left",invoke=moveTrackLeft}
 renoise.tool():add_keybinding{name="Global:Paketti:Move Track Right",invoke=moveTrackRight}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Move Track Left",invoke=moveTrackLeft}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Move Track Right",invoke=moveTrackRight}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Move Track Left",invoke=moveTrackLeft}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Move Track Right",invoke=moveTrackRight}
 ----
 function randomly_raise_selected_notes_one_octave(probability)
   local song=renoise.song()
@@ -5244,9 +5244,9 @@ function randomly_raise_selected_notes_one_octave(probability)
   end
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}
@@ -5503,12 +5503,12 @@ end
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Devices..:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Devices..:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
-renoise.tool():add_menu_entry{name="Mixer:Paketti..:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
+renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Devices..:Move DSPs to Previous Track",invoke=function() move_dsps_to_adjacent_track(-1) end}
+renoise.tool():add_menu_entry{name="Mixer:Paketti..:Devices..:Move DSPs to Next Track",invoke=function() move_dsps_to_adjacent_track(1) end}
 ---
 function move_selected_dsp_to_adjacent_track(direction)
   local song=renoise.song()
@@ -5575,8 +5575,8 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Move Selected DSP to 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Move Selected DSP to Next Track",invoke=function() move_selected_dsp_to_adjacent_track(1) end}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Move Selected DSP to Previous Track",invoke=function() move_selected_dsp_to_adjacent_track(-1) end}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Move Selected DSP to Next Track",invoke=function() move_selected_dsp_to_adjacent_track(1) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Move Selected DSP to Previous Track",invoke=function() move_selected_dsp_to_adjacent_track(-1) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Move Selected DSP to Next Track",invoke=function() move_selected_dsp_to_adjacent_track(1) end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Devices..:Move Selected DSP to Previous Track",invoke=function() move_selected_dsp_to_adjacent_track(-1) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Devices..:Move Selected DSP to Next Track",invoke=function() move_selected_dsp_to_adjacent_track(1) end}
 ---------
 function create_group_and_move_dsps()
   local song=renoise.song()
@@ -5642,7 +5642,7 @@ end
 
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Create Group and Move DSPs",invoke=create_group_and_move_dsps}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Create Group and Move DSPs",invoke=create_group_and_move_dsps}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Create Group and Move DSPs",invoke=create_group_and_move_dsps}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Create Group and Move DSPs",invoke=create_group_and_move_dsps}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Create Group and Move DSPs",invoke=create_group_and_move_dsps}
 
@@ -6147,8 +6147,7 @@ function pakettiVolumeInterpolationLooper()
 end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Pattern Editor..:Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Paketti Value Interpolation Looper Dialog...",invoke = pakettiVolumeInterpolationLooper}
 
@@ -6210,9 +6209,9 @@ local function handle_above_effect_command(operation)
   end
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Copy Above Effect Column",invoke=function() handle_above_effect_command("copy") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Copy Above Effect Column + Increase Value",invoke=function() handle_above_effect_command("inc") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Copy Above Effect Column + Decrease Value",invoke=function() handle_above_effect_command("dec") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Copy Above Effect Column",invoke=function() handle_above_effect_command("copy") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Copy Above Effect Column + Increase Value",invoke=function() handle_above_effect_command("inc") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Copy Above Effect Column + Decrease Value",invoke=function() handle_above_effect_command("dec") end}
 renoise.tool():add_keybinding{name="Global:Paketti:Copy Above Effect Column",invoke=function() handle_above_effect_command("copy") end}
 renoise.tool():add_keybinding{name="Global:Paketti:Copy Above Effect Column + Increase Value",invoke=function() handle_above_effect_command("inc") end}
 renoise.tool():add_keybinding{name="Global:Paketti:Copy Above Effect Column + Decrease Value",invoke=function() handle_above_effect_command("dec") end}
@@ -6550,7 +6549,7 @@ function noteOffPaste()
 end
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Note-Off Paste (from Selection)", invoke=function() noteOffPaste() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note-Off Paste (from Selection)", invoke=function() noteOffPaste() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Note-Off Paste (from Selection)", invoke=function() noteOffPaste() end}
 
 
 

--- a/PakettiPatternEditor.lua
+++ b/PakettiPatternEditor.lua
@@ -6622,6 +6622,3 @@ end
 
 renoise.tool():add_keybinding {name="Global:Paketti:Duplicate Selection in Pattern",invoke=function()duplicate_selection_pro()end}
 
-
-
-

--- a/PakettiPatternEditor.lua
+++ b/PakettiPatternEditor.lua
@@ -5244,9 +5244,9 @@ function randomly_raise_selected_notes_one_octave(probability)
   end
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Random..:Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Generate&Randomize..:Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 25% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.25) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 50% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.5) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Random Selected Notes Octave Up 75% Probability",invoke=function() randomly_raise_selected_notes_one_octave(0.75) end}

--- a/PakettiPatternMatrix.lua
+++ b/PakettiPatternMatrix.lua
@@ -91,7 +91,7 @@ end
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Pattern Above & Clear Muted Tracks",invoke=duplicate_pattern_and_clear_muted_above}
 renoise.tool():add_midi_mapping{name="Paketti:Duplicate Pattern Above & Clear Muted",invoke=duplicate_pattern_and_clear_muted_above}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Duplicate Pattern Above & Clear Muted",invoke=duplicate_pattern_and_clear_muted_above}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Duplicate Pattern Above & Clear Muted",invoke=duplicate_pattern_and_clear_muted_above}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Duplicate Pattern Above & Clear Muted",invoke=duplicate_pattern_and_clear_muted_above}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Duplicate Pattern Above & Clear Muted",invoke=duplicate_pattern_and_clear_muted_above}
 
 
@@ -162,7 +162,7 @@ end
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Pattern Below & Clear Muted Tracks",invoke=duplicate_pattern_and_clear_muted}
 renoise.tool():add_midi_mapping{name="Paketti:Duplicate Pattern Below & Clear Muted",invoke=duplicate_pattern_and_clear_muted}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Duplicate Pattern Below & Clear Muted",invoke=duplicate_pattern_and_clear_muted}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Duplicate Pattern Below & Clear Muted",invoke=duplicate_pattern_and_clear_muted}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Duplicate Pattern Below & Clear Muted",invoke=duplicate_pattern_and_clear_muted}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Duplicate Pattern Below & Clear Muted",invoke=duplicate_pattern_and_clear_muted}
 
 

--- a/PakettiRecorder.lua
+++ b/PakettiRecorder.lua
@@ -629,8 +629,8 @@ renoise.tool():add_keybinding{name="Global:Paketti:Paketti Overdub 01 (No Metron
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Overdub 01 (Metronome/Line Input)",invoke=function() recordtocurrenttrack(true, true,1) end}
 renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Record..:Paketti Overdub 01 (Metronome/Line Input)",invoke=function() recordtocurrenttrack(true, true,1) end}
 renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Record..:Paketti Overdub 01 (Metronome/No Line Input)",invoke=function() recordtocurrenttrack(true, false,1) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Paketti Overdub 01 (No Metronome/Line Input)",invoke=function() recordtocurrenttrack(false, true,1) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Paketti Overdub 01 (No Metronome/No Line Input)",invoke=function() recordtocurrenttrack(false, false,1) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Record..:Paketti Overdub 01 (No Metronome/Line Input)",invoke=function() recordtocurrenttrack(false, true,1) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Record..:Paketti Overdub 01 (No Metronome/No Line Input)",invoke=function() recordtocurrenttrack(false, false,1) end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Record..:Paketti Overdub 01 (Metronome/Line Input)",invoke=function() recordtocurrenttrack(true, true,1) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Record..:Paketti Overdub 01 (Metronome/No Line Input)",invoke=function() recordtocurrenttrack(true, false,1) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Record..:Paketti Overdub 01 (No Metronome/Line Input)",invoke=function() recordtocurrenttrack(false, true,1) end}

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -10315,7 +10315,7 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Fuzzy Search Track",i
 renoise.tool():add_keybinding{name="Pattern Matrix:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_menu_entry{name="Mixer:Paketti Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -7535,7 +7535,7 @@ end
 
 -- Trigger the dialog to show
 renoise.tool():add_keybinding{name="Global:Paketti:Open VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Volume/Delay/Pan Slider Controls...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_midi_mapping{name="Paketti:Open VolDelayPan Slider Dialog...",invoke=function(message)  if message:is_trigger() then pakettiVolDelayPanSliderDialog() end end}
 -----

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -1864,7 +1864,7 @@ function setToSelectedInstrument_DuplicateTrack()
   MarkTrackMarkPattern()
 end
 
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Duplicate Track, set to Selected Instrument",invoke=function() setToSelectedInstrument_DuplicateTrack() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Duplicate Track, set to Selected Instrument",invoke=function() setToSelectedInstrument_DuplicateTrack() end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Duplicate Track, set to Selected Instrument",invoke=function() setToSelectedInstrument_DuplicateTrack() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Track, set to Selected Instrument",invoke=function() setToSelectedInstrument_DuplicateTrack() end}
 
@@ -2017,7 +2017,7 @@ function duplicateTrackDuplicateInstrument()
   end
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Duplicate Track Duplicate Instrument",invoke=function() duplicateTrackDuplicateInstrument() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Duplicate Track Duplicate Instrument",invoke=function() duplicateTrackDuplicateInstrument() end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Duplicate Track Duplicate Instrument",invoke=function() duplicateTrackDuplicateInstrument() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Track Duplicate Instrument",invoke=function() duplicateTrackDuplicateInstrument() end}
 ------------
@@ -2423,8 +2423,8 @@ function create_identical_track()
 end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Create Identical Track",invoke=create_identical_track}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Create Phrase",invoke=function() createPhrase() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Create Identical Track",invoke=create_identical_track}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Create Phrase",invoke=function() createPhrase() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Create Identical Track",invoke=create_identical_track}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Create Identical Track",invoke=create_identical_track}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Create Identical Track",invoke=create_identical_track}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Pattern Editor..:Create Identical Track",invoke=create_identical_track}
@@ -3106,8 +3106,8 @@ end
 renoise.tool():add_keybinding{name="Global:Paketti:Roll the Dice on Notes",invoke=function()
 randomize_notes_in_selection() end}
 
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Roll the Dice on Notes in Selection",invoke=function() randomize_notes_in_selection() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Reverse Notes in Selection",invoke=PakettiReverseNotesInSelection}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Roll the Dice on Notes in Selection",invoke=function() randomize_notes_in_selection() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Reverse Notes in Selection",invoke=PakettiReverseNotesInSelection}
 
 
 -------
@@ -4045,8 +4045,8 @@ renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Track Properties
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Track Properties..:Increase All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(3) end}
 renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Decrease All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(-3) end}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Increase All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(3) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Decrease All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(-3) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Increase All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(3) end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Tracks..:Decrease All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(-3) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Increase All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(3) end}
 renoise.tool():add_keybinding{name="--Global:Paketti:Decrease All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(-3) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Increase All Track Volumes by 3dB", invoke=function() pakettiDumpAllTrackVolumes(3) end}
 -------
@@ -4118,11 +4118,11 @@ renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:R
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Resize&Fill..:Paketti Pattern Resize and Fill 128",invoke=function() pakettiResizeAndFill(128) end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Resize&Fill..:Paketti Pattern Resize and Fill 256",invoke=function() pakettiResizeAndFill(256) end}
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Pattern Editor..:Resize&Fill..:Paketti Pattern Resize and Fill 512",invoke=function() pakettiResizeAndFill(512) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize&Fill..:Paketti Pattern Resize and Fill 032",invoke=function() pakettiResizeAndFill(32) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize&Fill..:Paketti Pattern Resize and Fill 064",invoke=function() pakettiResizeAndFill(64) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize&Fill..:Paketti Pattern Resize and Fill 128",invoke=function() pakettiResizeAndFill(128) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize&Fill..:Paketti Pattern Resize and Fill 256",invoke=function() pakettiResizeAndFill(256) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize&Fill..:Paketti Pattern Resize and Fill 512",invoke=function() pakettiResizeAndFill(512) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize&Fill..:Paketti Pattern Resize and Fill 032",invoke=function() pakettiResizeAndFill(32) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize&Fill..:Paketti Pattern Resize and Fill 064",invoke=function() pakettiResizeAndFill(64) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize&Fill..:Paketti Pattern Resize and Fill 128",invoke=function() pakettiResizeAndFill(128) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize&Fill..:Paketti Pattern Resize and Fill 256",invoke=function() pakettiResizeAndFill(256) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize&Fill..:Paketti Pattern Resize and Fill 512",invoke=function() pakettiResizeAndFill(512) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Pattern Resize and Fill 032",invoke=function() pakettiResizeAndFill(32) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Pattern Resize and Fill 064",invoke=function() pakettiResizeAndFill(64) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Pattern Resize and Fill 128",invoke=function() pakettiResizeAndFill(128) end}
@@ -5252,7 +5252,7 @@ function resize_all_non_empty_patterns_to_current_pattern_length()
 end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to current Pattern length",invoke = resize_all_non_empty_patterns_to_current_pattern_length}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to current Pattern length",invoke = resize_all_non_empty_patterns_to_current_pattern_length}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to current Pattern length",invoke = resize_all_non_empty_patterns_to_current_pattern_length}
 renoise.tool():add_menu_entry{name="--Pattern Sequencer:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to current Pattern length",invoke = resize_all_non_empty_patterns_to_current_pattern_length}
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to 012",invoke=function() resize_all_non_empty_patterns_to(12) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to 016",invoke=function() resize_all_non_empty_patterns_to(016) end}
@@ -5266,18 +5266,18 @@ renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to 256",invoke=function() resize_all_non_empty_patterns_to(256) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to 384",invoke=function() resize_all_non_empty_patterns_to(384) end}
 renoise.tool():add_keybinding{name="Global:Paketti:Resize all non-empty Patterns to 512",invoke=function() resize_all_non_empty_patterns_to(512) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 012",invoke=function() resize_all_non_empty_patterns_to(12) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 016",invoke=function() resize_all_non_empty_patterns_to(016) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 024",invoke=function() resize_all_non_empty_patterns_to(024) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 032",invoke=function() resize_all_non_empty_patterns_to(032) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 048",invoke=function() resize_all_non_empty_patterns_to(048) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 064",invoke=function() resize_all_non_empty_patterns_to(064) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 096",invoke=function() resize_all_non_empty_patterns_to(96) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 128",invoke=function() resize_all_non_empty_patterns_to(128) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 192",invoke=function() resize_all_non_empty_patterns_to(192) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 256",invoke=function() resize_all_non_empty_patterns_to(256) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 384",invoke=function() resize_all_non_empty_patterns_to(384) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 512",invoke=function() resize_all_non_empty_patterns_to(512) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 012",invoke=function() resize_all_non_empty_patterns_to(12) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 016",invoke=function() resize_all_non_empty_patterns_to(016) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 024",invoke=function() resize_all_non_empty_patterns_to(024) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 032",invoke=function() resize_all_non_empty_patterns_to(032) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 048",invoke=function() resize_all_non_empty_patterns_to(048) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 064",invoke=function() resize_all_non_empty_patterns_to(064) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 096",invoke=function() resize_all_non_empty_patterns_to(96) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 128",invoke=function() resize_all_non_empty_patterns_to(128) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 192",invoke=function() resize_all_non_empty_patterns_to(192) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 256",invoke=function() resize_all_non_empty_patterns_to(256) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 384",invoke=function() resize_all_non_empty_patterns_to(384) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 512",invoke=function() resize_all_non_empty_patterns_to(512) end}
 renoise.tool():add_menu_entry{name="Pattern Sequencer:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 012",invoke=function() resize_all_non_empty_patterns_to(012) end}
 renoise.tool():add_menu_entry{name="Pattern Sequencer:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 016",invoke=function() resize_all_non_empty_patterns_to(016) end}
 renoise.tool():add_menu_entry{name="Pattern Sequencer:Paketti..:Resize all non-empty Patterns..:Resize all non-empty Patterns to 024",invoke=function() resize_all_non_empty_patterns_to(024) end}
@@ -7368,9 +7368,9 @@ end
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Interpolate Column Values (Volume)",invoke=function() volume_interpolation() end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Interpolate Column Values (Delay)",invoke=function() delay_interpolation() end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Interpolate Column Values (Panning)",invoke=function() panning_interpolation() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Interpolate Column Values (Volume)",invoke=function() volume_interpolation() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Interpolate Column Values (Delay)",invoke=function() delay_interpolation() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Interpolate Column Values (Panning)",invoke=function() panning_interpolation() end}
+renoise.tool():add_menu_entry{name="---Pattern Editor:Paketti..:Pattern..:Interpolate Column Values (Volume)",invoke=function() volume_interpolation() end}
+renoise.tool():add_menu_entry{name="---Pattern Editor:Paketti..:Pattern..:Interpolate Column Values (Delay)",invoke=function() delay_interpolation() end}
+renoise.tool():add_menu_entry{name="---Pattern Editor:Paketti..:Pattern..:Interpolate Column Values (Panning)",invoke=function() panning_interpolation() end}
 renoise.tool():add_midi_mapping{name="Paketti:Interpolate Column Values (Volume)",
   invoke=function(message) 
     if message:is_trigger() then volume_interpolation() end 
@@ -7472,7 +7472,7 @@ end
 
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Interpolate Column Values (Sample FX)",invoke=function() samplefx_interpolation() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Interpolate Column Values (Sample FX)",invoke=function() samplefx_interpolation() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Interpolate Column Values (Sample FX)",invoke=function() samplefx_interpolation() end}
 renoise.tool():add_midi_mapping{name="Paketti:Interpolate Column Values (Sample FX)",invoke=function(message) if message:is_trigger() then samplefx_interpolation() end  end}
 
 -- Show the GUI dialog
@@ -7535,7 +7535,7 @@ end
 
 -- Trigger the dialog to show
 renoise.tool():add_keybinding{name="Global:Paketti:Open VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Open VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Volume/Delay/Pan Slider Controls...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_midi_mapping{name="Paketti:Open VolDelayPan Slider Dialog...",invoke=function(message)  if message:is_trigger() then pakettiVolDelayPanSliderDialog() end end}
 -----
@@ -8118,9 +8118,9 @@ end
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Invert Note Column Subcolumns",invoke=function() invert_content("notecolumns") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Invert Effect Column Subcolumns",invoke=function() invert_content("effectcolumns") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Invert All Subcolumns",invoke=function() invert_content("all") end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Invert Note Column Subcolumns",invoke=function() invert_content("notecolumns") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Invert Effect Column Subcolumns",invoke=function() invert_content("effectcolumns") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Invert All Subcolumns",invoke=function() invert_content("all") end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Invert Note Column Subcolumns",invoke=function() invert_content("notecolumns") end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Effect Columns..:Invert Effect Column Subcolumns",invoke=function() invert_content("effectcolumns") end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Pattern..:Invert All Subcolumns",invoke=function() invert_content("all") end}
 
 
 ---
@@ -8806,10 +8806,10 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Wipe All Effect Colum
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Wipe All Effect Columns on Selected Track on Song",invoke=function() wipe_effect_columns(false, true) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Wipe All Effect Columns on Selected Pattern",invoke=function() wipe_effect_columns(true, false) end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Wipe All Effect Columns on Song",invoke=function() wipe_effect_columns(true, true) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Wipe All Effect Columns on Selected Track on Current Pattern",invoke=function() wipe_effect_columns(false, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Wipe All Effect Columns on Selected Track on Song",invoke=function() wipe_effect_columns(false, true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Wipe All Effect Columns on Selected Pattern",invoke=function() wipe_effect_columns(true, false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Wipe All Effect Columns on Song",invoke=function() wipe_effect_columns(true, true) end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Effect Columns..:Wipe All Effect Columns on Selected Track on Current Pattern",invoke=function() wipe_effect_columns(false, false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Wipe All Effect Columns on Selected Track on Song",invoke=function() wipe_effect_columns(false, true) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Wipe All Effect Columns on Selected Pattern",invoke=function() wipe_effect_columns(true, false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Effect Columns..:Wipe All Effect Columns on Song",invoke=function() wipe_effect_columns(true, true) end}
 
 function multiply_bpm_halve_lpb()
   local song=renoise.song()
@@ -8871,10 +8871,10 @@ function halve_bpm_multiply_lpb()
 end
 
 renoise.tool():add_keybinding{name="Global:Paketti:Multiply BPM & Halve LPB",invoke=function() multiply_bpm_halve_lpb() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Multiply BPM & Halve LPB",invoke=function() multiply_bpm_halve_lpb() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:BPM&LPB..:Multiply BPM & Halve LPB",invoke=function() multiply_bpm_halve_lpb() end}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Multiply BPM & Halve LPB",invoke=function() multiply_bpm_halve_lpb() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Halve BPM & Multiply LPB",invoke=function() halve_bpm_multiply_lpb() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Halve BPM & Multiply LPB",invoke=function() halve_bpm_multiply_lpb() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:BPM&LPB..:Halve BPM & Multiply LPB",invoke=function() halve_bpm_multiply_lpb() end}
 renoise.tool():add_menu_entry{name="Pattern Matrix:Paketti..:Halve BPM & Multiply LPB",invoke=function() halve_bpm_multiply_lpb() end}
 --------
 function sampleFXControls(scope, state)
@@ -8914,10 +8914,10 @@ renoise.tool():add_menu_entry{name="--Instrument Box:Paketti..:Enable All Sample
 renoise.tool():add_menu_entry{name="Instrument Box:Paketti..:Bypass All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", false) end}
 renoise.tool():add_menu_entry{name="Instrument Box:Paketti..:Enable All Sample FX on All Instruments",invoke=function() sampleFXControls("all", true) end}
 renoise.tool():add_menu_entry{name="Instrument Box:Paketti..:Bypass All Sample FX on All Instruments",invoke=function() sampleFXControls("all", false) end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Enable All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Bypass All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", false) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Enable All Sample FX on All Instruments",invoke=function() sampleFXControls("all", true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Bypass All Sample FX on All Instruments",invoke=function() sampleFXControls("all", false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Instrument..:Enable All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", true) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Instrument..:Bypass All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Instrument..:Enable All Sample FX on All Instruments",invoke=function() sampleFXControls("all", true) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Instrument..:Bypass All Sample FX on All Instruments",invoke=function() sampleFXControls("all", false) end}
 renoise.tool():add_menu_entry{name="--Sample FX Mixer:Paketti..:Enable All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", true) end}
 renoise.tool():add_menu_entry{name="Sample FX Mixer:Paketti..:Bypass All Sample FX on Selected Instrument",invoke=function() sampleFXControls("single", false) end}
 renoise.tool():add_menu_entry{name="Sample FX Mixer:Paketti..:Enable All Sample FX on All Instruments",invoke=function() sampleFXControls("all", true) end}
@@ -9145,7 +9145,7 @@ function pakettiFloodFillFromCurrentRow()
   renoise.app():show_status("Selection filled with contents of current row")
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Flood Fill from Current Row w/ AutoArp",invoke=pakettiFloodFillFromCurrentRow}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Flood Fill from Current Row w/ AutoArp",invoke=pakettiFloodFillFromCurrentRow}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Flood Fill from Current Row w/ AutoArp",invoke=pakettiFloodFillFromCurrentRow}
 --------
 function findUsedInstruments()
@@ -10315,9 +10315,9 @@ renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Fuzzy Search Track",i
 renoise.tool():add_keybinding{name="Pattern Matrix:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Fuzzy Search Track",invoke = pakettiFuzzySearchTrackDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
-renoise.tool():add_menu_entry{name="--Mixer:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
+renoise.tool():add_menu_entry{name="Mixer:Paketti Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Fuzzy Search Track...",invoke = pakettiFuzzySearchTrackDialog}
 -----------
 local dialog = nil
@@ -10566,7 +10566,7 @@ function NoteToInstrumentKeyhandler(dialog,key)
   end
 end
   
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Switch Note Instrument Dialog...",invoke=pakettiSwitchNoteInstrumentDialog}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Pattern..:Switch Note Instrument Dialog...",invoke=pakettiSwitchNoteInstrumentDialog}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Switch Note Instrument Dialog...",invoke=pakettiSwitchNoteInstrumentDialog}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Switch Note Instrument Dialog...",invoke=pakettiSwitchNoteInstrumentDialog}
 ------------------------------
@@ -10997,4 +10997,4 @@ function ConvertChordsToArpeggio()
 end
 
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Convert 3 Note Chord to Arpeggio", invoke=function() ConvertChordsToArpeggio() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Convert 3 Note Chord to Arpeggio", invoke=function() ConvertChordsToArpeggio() end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Convert 3 Note Chord to Arpeggio", invoke=function() ConvertChordsToArpeggio() end}

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -7535,7 +7535,7 @@ end
 
 -- Trigger the dialog to show
 renoise.tool():add_keybinding{name="Global:Paketti:Open VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti Tools..:VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Volume/Delay/Pan Slider Controls...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_midi_mapping{name="Paketti:Open VolDelayPan Slider Dialog...",invoke=function(message)  if message:is_trigger() then pakettiVolDelayPanSliderDialog() end end}
 -----

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -7535,7 +7535,7 @@ end
 
 -- Trigger the dialog to show
 renoise.tool():add_keybinding{name="Global:Paketti:Open VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:VolDelayPan Slider Dialog...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Volume/Delay/Pan Slider Controls...",invoke=function() pakettiVolDelayPanSliderDialog() end}
 renoise.tool():add_midi_mapping{name="Paketti:Open VolDelayPan Slider Dialog...",invoke=function(message)  if message:is_trigger() then pakettiVolDelayPanSliderDialog() end end}
 -----

--- a/PakettiRequests.lua
+++ b/PakettiRequests.lua
@@ -2023,7 +2023,7 @@ renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Track Duplicate Ins
 ------------
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Interpolate Notes",invoke=function() note_interpolation() end}
 renoise.tool():add_midi_mapping{name="Paketti:Interpolate Notes",invoke=function() note_interpolation() end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Note Columns..:Interpolate Notes",invoke=function() note_interpolation() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Note Columns..:Interpolate Notes",invoke=function() note_interpolation() end}
 
 -- Main function for note interpolation
 function note_interpolation()

--- a/PakettiSamples.lua
+++ b/PakettiSamples.lua
@@ -4593,7 +4593,7 @@ function duplicateTrackAndInstrument()
   renoise.app():show_status("Track and instrument duplicated successfully")
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Track..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Tracks..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}

--- a/PakettiSamples.lua
+++ b/PakettiSamples.lua
@@ -2262,7 +2262,7 @@ renoise.tool():add_menu_entry{name="Mixer:Paketti..:Clean Render..:Clean Render 
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Clean Render..:Clean Render and Save Selected Track/Group as .FLAC",invoke=function() CleanRenderAndSaveSelection("FLAC") end}
 renoise.tool():add_keybinding{name="Global:Paketti:Clean Render&Save Selected Track/Group (.WAV)",invoke=function() CleanRenderAndSaveSelection("WAV") end}
 renoise.tool():add_keybinding{name="Global:Paketti:Clean Render&Save Selected Track/Group (.FLAC)",invoke=function() CleanRenderAndSaveSelection("FLAC") end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Duplicate and Reverse Instrument",invoke=PakettiDuplicateAndReverseInstrument}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Instrument..:Duplicate and Reverse Instrument",invoke=PakettiDuplicateAndReverseInstrument}
 ---------
 function PakettiInjectDefaultXRNI()
   local instVol = renoise.song().selected_instrument.volume
@@ -3725,7 +3725,7 @@ function add_backwards_effect_to_selection()
   end
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Play Samples Backwards in Selection 0B00",invoke=add_backwards_effect_to_selection}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Play Samples Backwards in Selection 0B00",invoke=add_backwards_effect_to_selection}
 renoise.tool():add_keybinding{name="Global:Paketti:Play Samples Backwards in Selection 0B00",invoke=add_backwards_effect_to_selection}
 ---
 function PakettiRandomIR(ir_path)
@@ -4593,8 +4593,7 @@ function duplicateTrackAndInstrument()
   renoise.app():show_status("Track and instrument duplicated successfully")
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
-
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Track..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_keybinding{name="Mixer:Paketti:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_menu_entry{name="Mixer:Paketti..:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}
 renoise.tool():add_keybinding{name="Global:Paketti:Duplicate Track and Instrument",invoke=duplicateTrackAndInstrument}

--- a/PakettiSandbox.lua
+++ b/PakettiSandbox.lua
@@ -613,7 +613,7 @@ end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 -------
 

--- a/PakettiSandbox.lua
+++ b/PakettiSandbox.lua
@@ -613,7 +613,7 @@ end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 -------
 

--- a/PakettiSandbox.lua
+++ b/PakettiSandbox.lua
@@ -60,18 +60,18 @@ function showOnlyColumnType(column_type)
     renoise.app():show_status(message)
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle Show Only Effect Columns",invoke=function() showOnlyColumnType("effects") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle Show Only Effect Columns",invoke=function() showOnlyColumnType("effects") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Toggle Show Only Effect Columns",invoke=function() showOnlyColumnType("effects") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Show Only Effect Columns",invoke=function() showOnlyColumnType("effects") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Show Only Effect Columns",invoke=function() showOnlyColumnType("effects") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Show Only Volume Columns",invoke=function() showOnlyColumnType("volume") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Show Only Panning Columns",invoke=function() showOnlyColumnType("panning") end}
 renoise.tool():add_keybinding{name="Pattern Editor:Paketti:Show Only Delay Columns",invoke=function() showOnlyColumnType("delay") end}
@@ -652,8 +652,8 @@ function toggleColumns(include_sample_effects)
     renoise.app():show_status(message)
 end
 
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle All Columns",invoke=function() toggleColumns(true) end}
-renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Toggle All Columns (No Sample Effects)",invoke=function() toggleColumns(false) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle All Columns",invoke=function() toggleColumns(true) end}
+renoise.tool():add_menu_entry{name="Pattern Editor:Paketti..:Visible Columns..:Toggle All Columns (No Sample Effects)",invoke=function() toggleColumns(false) end}
 renoise.tool():add_menu_entry{name="Main Menu:View:Paketti..:Visible Columns..:Toggle All Columns",invoke=function() toggleColumns(true) end}
 renoise.tool():add_menu_entry{name="Main Menu:View:Paketti..:Visible Columns..:Toggle All Columns (No Sample Effects)",invoke=function() toggleColumns(false) end}
 

--- a/PakettiSandbox.lua
+++ b/PakettiSandbox.lua
@@ -611,8 +611,9 @@ function pakettiBeatStructureEditorDialog()
   renoise.app().window.active_middle_frame = 1
 end
 
-renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
-renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
+renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Matrix:Paketti..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Beat Structure Editor...",invoke=pakettiBeatStructureEditorDialog}
 -------
 

--- a/PakettiStretch.lua
+++ b/PakettiStretch.lua
@@ -1527,7 +1527,7 @@ end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 renoise.tool():add_menu_entry{name="--Instrument Box:Paketti..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 render_context = {
     source_track = 0,

--- a/PakettiStretch.lua
+++ b/PakettiStretch.lua
@@ -1527,7 +1527,7 @@ end
 
 renoise.tool():add_menu_entry{name="--Main Menu:Tools:Paketti..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 renoise.tool():add_menu_entry{name="--Instrument Box:Paketti..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:Paketti Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 renoise.tool():add_keybinding{name="Global:Paketti:Timestretch Dialog...",invoke=pakettiTimestretchDialog}
 render_context = {
     source_track = 0,

--- a/PakettiTupletGenerator.lua
+++ b/PakettiTupletGenerator.lua
@@ -363,4 +363,5 @@ function pakettiTupletDialog()
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Xperimental/Work in Progress..:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:(Xperimental) Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}

--- a/PakettiTupletGenerator.lua
+++ b/PakettiTupletGenerator.lua
@@ -363,5 +363,5 @@ function pakettiTupletDialog()
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Xperimental/Work in Progress..:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Tools..:(Xperimental) Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:(Xperimental) Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}

--- a/PakettiTupletGenerator.lua
+++ b/PakettiTupletGenerator.lua
@@ -363,5 +363,5 @@ function pakettiTupletDialog()
 end
 
 renoise.tool():add_menu_entry{name="Main Menu:Tools:Paketti..:Xperimental/Work in Progress..:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
-renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:(Xperimental) Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
+renoise.tool():add_menu_entry{name="--Pattern Editor:Paketti Gadgets..:(WIP) Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}
 renoise.tool():add_keybinding{name="Global:Paketti:Paketti Tuplet Writer Dialog...",invoke=function() pakettiTupletDialog() end}


### PR DESCRIPTION
1. Pattern Editor: Merged several functions of the right-click menu into submenus for better navigation:

![image](https://github.com/user-attachments/assets/3182066e-733c-4b80-9653-edfd4bb72e55)


2. Pattern Editor: Separated important dialogues right into the "Paketti Gadgets" submenu for ease of access, specially for beginners:

![image](https://github.com/user-attachments/assets/7eb57e6d-4b87-40dd-af81-ac7aa8bb25d6)

This concept could be expanded to include subcategories (ex: Paketti Gadgets..>Utility, Sequencing, etc).
I believe this would help newcomers get into Paketti.
