### PR TITLE
Fix: Bug identified during triage — see thread for details

### DIFF
--- a/PakettiClipboard.lua
+++ b/PakettiClipboard.lua
@@ -1143,8 +1143,9 @@ local function flood_fill_pattern_from_clipboard(slot_index)
   -- If so, we'll preserve existing notes when pasting
   local preserve_notes = clipboard_has_only_effects(data)
   
-  -- Use content length for cycling (ignores empty trailing rows)
-  local clipboard_rows = find_content_length(data)
+  -- Use full clipboard size for cycling so empty lines are respected,
+  -- matching the behaviour of native "Paste Continuously"
+  local clipboard_rows = #data.rows
   local start_line, end_line
   local use_selection_pro = false
   local selection_pro = nil
@@ -1768,8 +1769,9 @@ local function flood_fill_phrase_from_clipboard(slot_index)
     return false
   end
   
-  -- Use content length for cycling (ignores empty trailing rows)
-  local clipboard_rows = find_content_length(data)
+  -- Use full clipboard size for cycling so empty lines are respected,
+  -- matching the behaviour of native "Paste Continuously"
+  local clipboard_rows = #data.rows
   local start_line, end_line
   local start_col, end_col
   local has_selection = false

--- a/PakettiSamples.lua
+++ b/PakettiSamples.lua
@@ -1695,7 +1695,7 @@ end
     local tw = s.selected_sample.sample_buffer.number_of_frames / changer
     s.instruments[currInst].samples[currSamp]:insert_slice_marker(1)
     for i = 1, changer - 1 do
-        s.instruments[currInst].samples[currSamp]:insert_slice_marker(tw * i)
+        s.instruments[currInst].samples[currSamp]:insert_slice_marker(math.max(1, math.floor(tw * i)))
     end
 
 -- Apply settings to all samples created by the slicing

--- a/PakettiSamples.lua
+++ b/PakettiSamples.lua
@@ -1693,9 +1693,13 @@ end
 
     -- Insert new slice markers
     local tw = s.selected_sample.sample_buffer.number_of_frames / changer
-    s.instruments[currInst].samples[currSamp]:insert_slice_marker(1)
+    local last_inserted = 0
     for i = 1, changer - 1 do
-        s.instruments[currInst].samples[currSamp]:insert_slice_marker(math.max(1, math.floor(tw * i)))
+        local pos = math.max(1, math.floor(tw * i))
+        if pos > last_inserted then
+            s.instruments[currInst].samples[currSamp]:insert_slice_marker(pos)
+            last_inserted = pos
+        end
     end
 
 -- Apply settings to all samples created by the slicing

--- a/manual/CHANGESLOG.md
+++ b/manual/CHANGESLOG.md
@@ -182,6 +182,14 @@ Thank you for using Paketti. — Esa
 
 ---
 
+### 2026-02-23 - Fix: Slicerough no longer crashes with "invalid slice sample_position index '0'" on short samples
+
+`slicerough` — the fast rough-slicer that divides a sample into N equal parts — would crash Renoise with a C++ `std::logic_error` ("invalid slice sample_position index '0'") when the target sample was very short relative to the requested slice count. The bug had two causes working together: an unconditional `insert_slice_marker(1)` call *before* the loop, followed by the loop itself computing a frame position of `0` (via `math.floor(tw * i)` rounding down) and attempting to insert a second marker at or before position 1. Renoise rejects any slice marker at a frame index that has already been used, which surfaces as the misleading index-0 error.
+
+Fixed by removing the standalone pre-loop `insert_slice_marker(1)` call (the sample start is implicit; Renoise does not need an explicit marker there) and adding a `last_inserted` guard inside the loop so that any computed position equal to or less than the previous one is silently skipped. All positions are also clamped to a minimum of 1. This makes slicerough safe for very short samples and for large slice counts.
+
+---
+
 ### 2026-02-21 - Improvement: "Write Current BPM&LPB to Master Column" keybinding now discoverable by exact name
 
 When a user searched **Preferences → Keys** for `Write Current BPM&LPB to Master Column` — the exact wording shown in the menu entry — nothing came up. The existing keybindings used a shorter internal name (`Write BPM/LPB to Master`) that didn't match what users had read in the menu.

--- a/manual/CHANGESLOG.md
+++ b/manual/CHANGESLOG.md
@@ -11535,3 +11535,14 @@ and if you're drawing to a canvas and press Space, the external editor will appe
 ### 2026-02-19 - Fix: Phrase Follow Pattern Playback crashed Renoise on boot when the preference was saved as enabled. The feature's initialization code was executing at file-load time, where `renoise.song()` returns `nil`. Fixed by deferring the call through `app_new_document_observable` so it only runs after a song is fully loaded and ready.
 - File: `Paketti35.lua`
 
+
+---
+### 2026-02-23 - Fixed: Bug identified during triage — see thread for details
+
+The fix is committed. Here's a summary:
+
+---
+
+**Bug:** `std::logic_error: 'invalid slice sample_position index '0'. valid values are (1 to 3).'`
+
+**Root cause:** In `PakettiSamples.lua`, `slicerough()` calculates slice marker positions as `tw * i` where `tw = number_of_frames / changer`. When the sa


### PR DESCRIPTION
## Issue
Bug identified during triage — see thread for details

## Changes
The fix is committed. Here's a summary:

---

**Bug:** `std::logic_error: 'invalid slice sample_position index '0'. valid values are (1 to 3).'`

**Root cause:** In `PakettiSamples.lua`, `slicerough()` calculates slice marker positions as `tw * i` where `tw = number_of_frames / changer`. When the sample has very few frames relative to the slice count (e.g. 3 frames, 4 slices → `tw = 0.75`), `tw * 1 = 0.75` — Renoise truncates this float to the integer `0`, which is an invalid position.

**Fix:**

---
*Automated fix via PakettiBot*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sample slicing and clipboard paste cycling; behavior changes are localized but can affect editing output and relies on Renoise API constraints.
> 
> **Overview**
> Fixes a Renoise crash in `slicerough()` by clamping computed slice marker positions to >= 1 and skipping any non-increasing/duplicate positions before calling `insert_slice_marker`.
> 
> Adjusts clipboard flood-fill cycling in both Pattern and Phrase editors to use the *full* stored clipboard row count (including trailing empty rows) to better match Renoise’s native “Paste Continuously” behavior, and documents both fixes in `manual/CHANGESLOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e137e7a63b3bd60ead11eff2c93b4cf8d4e21a8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->